### PR TITLE
Erroneous mkdir Exception on consecutive runs

### DIFF
--- a/src/main/java/com/edugility/liquibase/maven/AssembleChangeLogMojo.java
+++ b/src/main/java/com/edugility/liquibase/maven/AssembleChangeLogMojo.java
@@ -912,7 +912,7 @@ public class AssembleChangeLogMojo extends AbstractLiquibaseMojo {
     }
     final File parent = this.outputFile.getParentFile();
     if (parent != null) {
-      if (!parent.mkdirs()) {
+      if (!parent.exists() && !parent.mkdirs()) {
         throw new IOException("Could not create parent directory chain for " + this.outputFile);
       }
     }


### PR DESCRIPTION
An Exception is erroneously thrown if the directory for generated change log already exists. This stops the plugin from being run consecutively without performing a maven clean.
